### PR TITLE
feat(todoist): add new entry processor to save entries to Todoist

### DIFF
--- a/feedly_saved_entries_processor/entry_processors/__init__.py
+++ b/feedly_saved_entries_processor/entry_processors/__init__.py
@@ -1,0 +1,1 @@
+"""Entry processors for Feedly saved entries."""

--- a/feedly_saved_entries_processor/entry_processors/base_entry_processor.py
+++ b/feedly_saved_entries_processor/entry_processors/base_entry_processor.py
@@ -1,0 +1,13 @@
+"""Base class for processing Feedly entries."""
+
+from abc import ABC, abstractmethod
+
+from feedly_saved_entries_processor.feedly_client import Entry
+
+
+class BaseEntryProcessor(ABC):
+    """Base class for processing Feedly entries."""
+
+    @abstractmethod
+    def process_entry(self, entry: Entry) -> None:
+        """Process a single Feedly entry."""

--- a/feedly_saved_entries_processor/entry_processors/todoist_entry_processor.py
+++ b/feedly_saved_entries_processor/entry_processors/todoist_entry_processor.py
@@ -35,7 +35,11 @@ class TodoistEntryProcessor(BaseEntryProcessor):
 
     def process_entry(self, entry: Entry) -> None:
         """Process a Feedly entry by adding it as a task to Todoist."""
-        task_content = f"{entry.title} - {entry.canonical_url or entry.origin.html_url if entry.origin else 'No URL'}"
+        if entry.canonical_url is None:
+            error_message = "Entry must have a canonical_url to be processed by TodoistEntryProcessor."
+            raise ValueError(error_message)
+
+        task_content = f"{entry.title} - {entry.canonical_url}"
 
         task = self.todoist_client.add_task(
             content=task_content,

--- a/feedly_saved_entries_processor/entry_processors/todoist_entry_processor.py
+++ b/feedly_saved_entries_processor/entry_processors/todoist_entry_processor.py
@@ -1,0 +1,48 @@
+"""Todoist entry processor."""
+
+import datetime
+import os
+from dataclasses import dataclass, field
+from typing import Literal
+
+from logzero import logger
+from todoist_api_python.api import TodoistAPI
+
+from feedly_saved_entries_processor.entry_processors.base_entry_processor import (
+    BaseEntryProcessor,
+)
+from feedly_saved_entries_processor.feedly_client import Entry
+
+
+@dataclass()
+class TodoistEntryProcessor(BaseEntryProcessor):
+    """A processor that saves Feedly entries as tasks in Todoist."""
+
+    project_id: str
+    due_datetime: datetime.datetime | None = None
+    priority: Literal[1, 2, 3, 4] | None = None
+
+    todoist_client: TodoistAPI = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize the Todoist API client."""
+        api_token = os.environ["TODOIST_API_TOKEN"]
+        self.todoist_client = TodoistAPI(api_token)
+
+    def process_entry(self, entry: Entry) -> None:
+        """Process a Feedly entry by adding it as a task to Todoist."""
+        task_content = f"{entry.title} - {entry.canonical_url or entry.origin.html_url if entry.origin else 'No URL'}"
+
+        try:
+            task = self.todoist_client.add_task(
+                content=task_content,
+                project_id=self.project_id,
+                priority=self.priority,
+                due_datetime=self.due_datetime,
+                description=entry.summary.content if entry.summary else None,
+            )
+        except Exception as e:
+            logger.error(f"Failed to add task to Todoist: {e}")
+            raise
+
+        logger.info(f"Added task to Todoist: {task.content} (ID: {task.id})")

--- a/feedly_saved_entries_processor/entry_processors/todoist_entry_processor.py
+++ b/feedly_saved_entries_processor/entry_processors/todoist_entry_processor.py
@@ -26,7 +26,11 @@ class TodoistEntryProcessor(BaseEntryProcessor):
 
     def __post_init__(self) -> None:
         """Initialize the Todoist API client."""
-        api_token = os.environ["TODOIST_API_TOKEN"]
+        api_token = os.environ.get("TODOIST_API_TOKEN")
+        if not api_token:
+            error_message = "TODOIST_API_TOKEN environment variable must be set"
+            raise ValueError(error_message)
+
         self.todoist_client = TodoistAPI(api_token)
 
     def process_entry(self, entry: Entry) -> None:

--- a/feedly_saved_entries_processor/entry_processors/todoist_entry_processor.py
+++ b/feedly_saved_entries_processor/entry_processors/todoist_entry_processor.py
@@ -37,16 +37,12 @@ class TodoistEntryProcessor(BaseEntryProcessor):
         """Process a Feedly entry by adding it as a task to Todoist."""
         task_content = f"{entry.title} - {entry.canonical_url or entry.origin.html_url if entry.origin else 'No URL'}"
 
-        try:
-            task = self.todoist_client.add_task(
-                content=task_content,
-                project_id=self.project_id,
-                priority=self.priority,
-                due_datetime=self.due_datetime,
-                description=entry.summary.content if entry.summary else None,
-            )
-        except Exception as e:
-            logger.error(f"Failed to add task to Todoist: {e}")
-            raise
+        task = self.todoist_client.add_task(
+            content=task_content,
+            project_id=self.project_id,
+            priority=self.priority,
+            due_datetime=self.due_datetime,
+            description=entry.summary.content if entry.summary else None,
+        )
 
         logger.info(f"Added task to Todoist: {task.content} (ID: {task.id})")

--- a/poetry.lock
+++ b/poetry.lock
@@ -167,6 +167,25 @@ files = [
 markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
+name = "dataclass-wizard"
+version = "0.35.1"
+description = "Lightning-fast JSON wizardry for Python dataclasses — effortless serialization right out of the box!"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "dataclass-wizard-0.35.1.tar.gz", hash = "sha256:18c780e3c574c3534cb2bbc447025cff140f0e640cd98e143a7d234c6445d09e"},
+    {file = "dataclass_wizard-0.35.1-py2.py3-none-any.whl", hash = "sha256:30858e14d780a40792fa190d55220a12cd0ef02a3d8fb8373b1eb4363d4b5549"},
+]
+
+[package.extras]
+dev = ["Sphinx (==7.4.7) ; python_version == \"3.9\"", "Sphinx (==8.1.3) ; python_version >= \"3.10\"", "attrs (==24.3.0)", "bump2version (==1.0.1)", "coverage (>=6.2)", "dacite (==1.8.1)", "dataclass-factory (==2.16)", "dataclass-wizard[toml]", "dataclasses-json (==0.6.7)", "flake8 (>=3)", "jsons (==1.6.3)", "mashumaro (==3.15)", "matplotlib", "pip (>=21.3.1)", "pydantic (==2.10.3)", "pytest (==8.3.4)", "pytest-benchmark[histogram]", "pytest-cov (==6.0.0)", "pytest-mock (>=3.6.1)", "python-dotenv (>=1,<2)", "pytimeparse (==1.1.8)", "sphinx-autodoc-typehints (==2.5.0)", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)", "tox (==4.23.2)", "twine (==6.0.1)", "typing-extensions (>=4.9.0)", "watchdog[watchmedo] (==6.0.0)", "wheel (==0.45.1)"]
+dotenv = ["python-dotenv (>=1,<2)"]
+timedelta = ["pytimeparse (>=1.1.7)"]
+toml = ["tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)"]
+yaml = ["PyYAML (>=6,<7)"]
+
+[[package]]
 name = "feedly-client"
 version = "0.26"
 description = "A lightweight client for the feedly api (https://developers.feedly.com)."
@@ -545,6 +564,24 @@ pygments = ">=2.7.2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0"},
+    {file = "pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "requests"
 version = "2.32.4"
 description = "Python HTTP for Humans."
@@ -626,6 +663,23 @@ files = [
 ]
 
 [[package]]
+name = "todoist-api-python"
+version = "3.1.0"
+description = "Official Python SDK for the Todoist API."
+optional = false
+python-versions = "~=3.9"
+groups = ["main"]
+files = [
+    {file = "todoist_api_python-3.1.0-py3-none-any.whl", hash = "sha256:20ee2445983235566e7f2b2c82f769b9a265bb3fa6d7aad3fa73cf9e2d4cd787"},
+    {file = "todoist_api_python-3.1.0.tar.gz", hash = "sha256:7cad732f58a4bdfbd1c073a1a8be1c1b4e13ae0c8be210bb7840fbba06eb987c"},
+]
+
+[package.dependencies]
+annotated-types = "*"
+dataclass-wizard = ">=0.35.0,<1.0"
+requests = ">=2.32.3,<3"
+
+[[package]]
 name = "typer"
 version = "0.16.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -690,5 +744,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.13"
-content-hash = "efa6d799a808e43d21a6e3eb64d4a5de0501a06b2d45e5fa4b1cd001fccc3db5"
+python-versions = "~=3.13"
+content-hash = "06b8c6c66393827ab08f250511852c2e888e19ef78e94b6b9aaf9261457ba7ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ authors = [
     {name = "dmingn",email = "dmingn@users.noreply.github.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = "~=3.13"
 dependencies = [
     "feedly-client (>=0.26,<0.27)",
     "logzero (>=1.7.0,<2.0.0)",
     "pydantic (>=2.11.7,<3.0.0)",
+    "todoist-api-python (>=3.1.0,<4.0.0)",
     "typer (>=0.16.0,<0.17.0)"
 ]
 
@@ -38,6 +39,7 @@ ignore_missing_imports = true
 mypy = "^1.17.1"
 ruff = "^0.12.7"
 pytest = "^8.4.1"
+pytest-mock = "^3.12.0"
 
 [tool.ruff]
 line-length = 88

--- a/tests/entry_processors/__init__.py
+++ b/tests/entry_processors/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for entry processors."""

--- a/tests/entry_processors/test_todoist_entry_processor.py
+++ b/tests/entry_processors/test_todoist_entry_processor.py
@@ -57,12 +57,6 @@ def entry_builder() -> Callable[..., Entry]:
     return _builder
 
 
-@pytest.fixture
-def sample_entry(entry_builder: Callable[..., Entry]) -> Entry:
-    """Fixture for a sample Entry object using the builder."""
-    return entry_builder()
-
-
 def test_post_init(
     mock_todoist_api: MagicMock, todoist_processor: TodoistEntryProcessor
 ) -> None:

--- a/tests/entry_processors/test_todoist_entry_processor.py
+++ b/tests/entry_processors/test_todoist_entry_processor.py
@@ -1,0 +1,168 @@
+"""Tests for the TodoistEntryProcessor."""
+
+import datetime
+from collections.abc import Callable
+from typing import Literal
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from feedly_saved_entries_processor.entry_processors.todoist_entry_processor import (
+    TodoistEntryProcessor,
+)
+from feedly_saved_entries_processor.feedly_client import Entry, Origin, Summary
+
+
+@pytest.fixture
+def mock_todoist_api(mocker: MockerFixture) -> MagicMock:
+    """Fixture for mocking TodoistAPI."""
+    mock_api: MagicMock = mocker.patch(
+        "feedly_saved_entries_processor.entry_processors.todoist_entry_processor.TodoistAPI"
+    )
+    return mock_api
+
+
+@pytest.fixture
+def todoist_processor(
+    mocker: MockerFixture, mock_todoist_api: MagicMock
+) -> TodoistEntryProcessor:
+    """Fixture for TodoistEntryProcessor instance."""
+    mocker.patch.dict("os.environ", {"TODOIST_API_TOKEN": "test_token"})
+    project_id = "test_project_id"
+    processor = TodoistEntryProcessor(project_id=project_id)
+    processor.todoist_client = mock_todoist_api
+    return processor
+
+
+@pytest.fixture
+def entry_builder() -> Callable[..., Entry]:
+    """Fixture for a builder function to create Entry objects."""
+
+    def _builder(
+        title: str = "Test Entry",
+        canonical_url: str | None = "http://example.com/test",
+        summary_content: str | None = "Test Summary Content",
+    ) -> Entry:
+        return Entry(
+            id="test_id",
+            title=title,
+            canonical_url=canonical_url,
+            origin=Origin(
+                title="Test Origin",
+                html_url="http://example.com",
+                stream_id="test_stream_id",
+            ),
+            summary=Summary(content=summary_content) if summary_content else None,
+            published=1234567890,
+            author=None,
+        )
+
+    return _builder
+
+
+@pytest.fixture
+def sample_entry(entry_builder: Callable[..., Entry]) -> Entry:
+    """Fixture for a sample Entry object using the builder."""
+    return entry_builder()
+
+
+def test_post_init(
+    mock_todoist_api: MagicMock, todoist_processor: TodoistEntryProcessor
+) -> None:
+    """Test that the Todoist API client is initialized correctly."""
+    assert todoist_processor.todoist_client is not None
+    assert todoist_processor.todoist_client == mock_todoist_api
+
+
+def test_process_entry_success(
+    mock_todoist_api: MagicMock,
+    todoist_processor: TodoistEntryProcessor,
+    entry_builder: Callable[..., Entry],
+) -> None:
+    """Test successful processing of an entry."""
+    sample_entry = entry_builder()
+    mock_todoist_api.add_task.return_value.id = "task_123"
+    mock_todoist_api.add_task.return_value.content = "Test Task"
+
+    todoist_processor.process_entry(sample_entry)
+
+    expected_content = "Test Entry - http://example.com/test"
+    mock_todoist_api.add_task.assert_called_once_with(
+        content=expected_content,
+        project_id=todoist_processor.project_id,
+        priority=None,
+        due_datetime=None,
+        description="Test Summary Content",
+    )
+
+
+def test_process_entry_no_canonical_url(
+    mock_todoist_api: MagicMock,
+    todoist_processor: TodoistEntryProcessor,
+    entry_builder: Callable[..., Entry],
+) -> None:
+    """Test processing of an entry without a canonical URL."""
+    entry = entry_builder(
+        canonical_url=None, title="Test Entry No URL", summary_content=None
+    )
+    mock_todoist_api.add_task.return_value.id = "task_456"
+    mock_todoist_api.add_task.return_value.content = "Test Task No URL"
+
+    todoist_processor.process_entry(entry)
+
+    expected_content = "Test Entry No URL - http://example.com"
+    mock_todoist_api.add_task.assert_called_once_with(
+        content=expected_content,
+        project_id=todoist_processor.project_id,
+        priority=None,
+        due_datetime=None,
+        description=None,
+    )
+
+
+def test_process_entry_add_task_failure(
+    mock_todoist_api: MagicMock,
+    todoist_processor: TodoistEntryProcessor,
+    entry_builder: Callable[..., Entry],
+) -> None:
+    """Test error handling when adding a task fails."""
+    sample_entry = entry_builder()
+    mock_todoist_api.add_task.side_effect = Exception("API Error")
+
+    with pytest.raises(Exception, match="API Error"):
+        todoist_processor.process_entry(sample_entry)
+
+    mock_todoist_api.add_task.assert_called_once()
+
+
+def test_process_entry_with_optional_params(
+    mock_todoist_api: MagicMock,
+    todoist_processor: TodoistEntryProcessor,
+    entry_builder: Callable[..., Entry],
+) -> None:
+    """Test processing of an entry with optional parameters (due_datetime, priority)."""
+    due_datetime = datetime.datetime(2025, 12, 31, 23, 59, 59, tzinfo=datetime.UTC)
+    priority: Literal[1, 2, 3, 4] = 2  # Use Literal for type hint
+
+    todoist_processor.due_datetime = due_datetime
+    todoist_processor.priority = priority
+
+    entry = entry_builder(
+        title="Entry with Params",
+        canonical_url="http://example.com/params",
+        summary_content="Summary for params",
+    )
+    mock_todoist_api.add_task.return_value.id = "task_789"
+    mock_todoist_api.add_task.return_value.content = "Test Task with Params"
+
+    todoist_processor.process_entry(entry)
+
+    expected_content = "Entry with Params - http://example.com/params"
+    mock_todoist_api.add_task.assert_called_once_with(
+        content=expected_content,
+        project_id=todoist_processor.project_id,
+        priority=priority,
+        due_datetime=due_datetime,
+        description="Summary for params",
+    )

--- a/tests/entry_processors/test_todoist_entry_processor.py
+++ b/tests/entry_processors/test_todoist_entry_processor.py
@@ -95,28 +95,19 @@ def test_process_entry_success(
 
 
 def test_process_entry_no_canonical_url(
-    mock_todoist_api: MagicMock,
     todoist_processor: TodoistEntryProcessor,
     entry_builder: Callable[..., Entry],
 ) -> None:
-    """Test processing of an entry without a canonical URL."""
+    """Test processing of an entry without a canonical URL raises an error."""
     entry = entry_builder(
         canonical_url=None, title="Test Entry No URL", summary_content=None
     )
-    mock_instance = mock_todoist_api.return_value
-    mock_instance.add_task.return_value.id = "task_456"
-    mock_instance.add_task.return_value.content = "Test Task No URL"
 
-    todoist_processor.process_entry(entry)
-
-    expected_content = "Test Entry No URL - http://example.com"
-    mock_instance.add_task.assert_called_once_with(
-        content=expected_content,
-        project_id=todoist_processor.project_id,
-        priority=None,
-        due_datetime=None,
-        description=None,
-    )
+    with pytest.raises(
+        ValueError,
+        match="Entry must have a canonical_url to be processed by TodoistEntryProcessor.",
+    ):
+        todoist_processor.process_entry(entry)
 
 
 def test_process_entry_add_task_failure(


### PR DESCRIPTION
This commit introduces a new entry processor that allows users to save their Feedly "Saved for Later" entries as tasks in Todoist.

Key changes include:
- A `BaseEntryProcessor` abstract class to provide a common interface for different entry processing services.
- The `TodoistEntryProcessor` class, which connects to the Todoist API and creates a new task for each Feedly entry. The task content includes the entry's title and URL, and the description contains the entry's summary.
- New dependencies added to `pyproject.toml`: `todoist-api-python` for the integration and `pytest-mock` for testing.
- Comprehensive unit tests for the `TodoistEntryProcessor` to ensure its functionality, including handling of optional parameters and API errors.
