### PR TITLE
feat: Implement configuration file loading and validation

### DIFF
--- a/feedly_saved_entries_processor/config_loader.py
+++ b/feedly_saved_entries_processor/config_loader.py
@@ -1,0 +1,69 @@
+"""Configuration loading and validation for Feedly Saved Entries Processor."""
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic_yaml import parse_yaml_raw_as, to_yaml_str
+from ruamel.yaml.error import YAMLError
+
+
+class MatchConfig(BaseModel):
+    """Configuration for matching Feedly entries."""
+
+    stream_id_in: tuple[str, ...] | None = None
+    model_config = ConfigDict(frozen=True)
+
+
+class Rule(BaseModel):
+    """Defines a single processing rule for Feedly entries."""
+
+    name: str
+    match: MatchConfig
+    processor: str
+    processor_config: dict[str, Any] = Field(default_factory=dict)
+    model_config = ConfigDict(frozen=True)
+
+
+class Config(BaseModel):
+    """Overall configuration for the Feedly Saved Entries Processor."""
+
+    rules: tuple[Rule, ...]
+    model_config = ConfigDict(frozen=True)
+
+
+def load_config(file_path: Path) -> Config:
+    """Load and validate the configuration from a YAML file.
+
+    Args:
+        file_path: The path to the YAML configuration file.
+
+    Returns
+    -------
+        A Config object representing the loaded configuration.
+
+    Raises
+    ------
+        FileNotFoundError: If the configuration file does not exist.
+        ValueError: If there is an error parsing or validating the configuration file.
+    """
+    if not file_path.exists():
+        msg = f"Configuration file not found: {file_path}"
+        raise FileNotFoundError(msg)
+
+    try:
+        yaml_content = file_path.read_text(encoding="utf-8")
+        return parse_yaml_raw_as(Config, yaml_content)
+    except (YAMLError, ValidationError) as e:
+        msg = f"Error parsing configuration file {file_path}: {e}"
+        raise ValueError(msg) from e
+
+
+def save_config(config: Config, file_path: Path) -> None:
+    """Save the configuration to a YAML file.
+
+    Args:
+        config: The Config object to save.
+        file_path: The path to the YAML file where the configuration will be saved.
+    """
+    file_path.write_text(to_yaml_str(config), encoding="utf-8")

--- a/poetry.lock
+++ b/poetry.lock
@@ -527,6 +527,27 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-yaml"
+version = "1.6.0"
+description = "YAML reading/writing for Pydantic models"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pydantic_yaml-1.6.0-py3-none-any.whl", hash = "sha256:02cb800b455b68daeeb74ad736c252a94a0b203da5fbbeef02539d468e1d98f8"},
+    {file = "pydantic_yaml-1.6.0.tar.gz", hash = "sha256:ce5f10b65d95ca45846a36ea8dae54e550fa3058e7d6218e0179184d9bf6f660"},
+]
+
+[package.dependencies]
+pydantic = ">=1.8"
+"ruamel.yaml" = ">=0.17.0,<0.19.0"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+dev = ["mypy (==1.17.1)", "pre-commit (==4.2.0)", "pytest (==8.4.1)", "ruff (==0.12.8)", "setuptools (>=61.0.0)", "setuptools-scm[toml] (>=6.2)"]
+docs = ["mkdocs", "mkdocs-material", "mkdocstrings[python]", "pygments", "pymdown-extensions", "types-setuptools"]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -621,6 +642,82 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.18.14"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "ruamel.yaml-0.18.14-py3-none-any.whl", hash = "sha256:710ff198bb53da66718c7db27eec4fbcc9aa6ca7204e4c1df2f282b6fe5eb6b2"},
+    {file = "ruamel.yaml-0.18.14.tar.gz", hash = "sha256:7227b76aaec364df15936730efbf7d72b30c0b79b1d578bbb8e3dcb2d81f52b7"},
+]
+
+[package.dependencies]
+"ruamel.yaml.clib" = {version = ">=0.2.7", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.14\""}
+
+[package.extras]
+docs = ["mercurial (>5.7)", "ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.12"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "platform_python_implementation == \"CPython\" and python_version == \"3.13\""
+files = [
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:11f891336688faf5156a36293a9c362bdc7c88f03a8a027c2c1d8e0bcde998e5"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a606ef75a60ecf3d924613892cc603b154178ee25abb3055db5062da811fd969"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd5415dded15c3822597455bc02bcd66e81ef8b7a48cb71a33628fc9fdde39df"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f66efbc1caa63c088dead1c4170d148eabc9b80d95fb75b6c92ac0aad2437d76"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:22353049ba4181685023b25b5b51a574bce33e7f51c759371a7422dcae5402a6"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:932205970b9f9991b34f55136be327501903f7c66830e9760a8ffb15b07f05cd"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a52d48f4e7bf9005e8f0a89209bf9a73f7190ddf0489eee5eb51377385f59f2a"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-win32.whl", hash = "sha256:3eac5a91891ceb88138c113f9db04f3cebdae277f5d44eaa3651a4f573e6a5da"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab007f2f5a87bd08ab1499bdf96f3d5c6ad4dcfa364884cb4549aa0154b13a28"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:d84318609196d6bd6da0edfa25cedfbabd8dbde5140a0a23af29ad4b8f91fb1e"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb43a269eb827806502c7c8efb7ae7e9e9d0573257a46e8e952f4d4caba4f31e"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:943f32bc9dedb3abff9879edc134901df92cfce2c3d5c9348f172f62eb2d771d"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c3829bb364fdb8e0332c9931ecf57d9be3519241323c5274bd82f709cebc0c"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e7e3736715fbf53e9be2a79eb4db68e4ed857017344d697e8b9749444ae57475"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7e75b4965e1d4690e93021adfcecccbca7d61c7bddd8e22406ef2ff20d74ef"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:fc4b630cd3fa2cf7fce38afa91d7cfe844a9f75d7f0f36393fa98815e911d987"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bc5f1e1c28e966d61d2519f2a3d451ba989f9ea0f2307de7bc45baa526de9e45"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a0e060aace4c24dcaf71023bbd7d42674e3b230f7e7b97317baf1e953e5b519"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2f1c3765db32be59d18ab3953f43ab62a761327aafc1594a2a1fbe038b8b8a7"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d85252669dc32f98ebcd5d36768f5d4faeaeaa2d655ac0473be490ecdae3c285"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e143ada795c341b56de9418c58d028989093ee611aa27ffb9b7f609c00d813ed"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2c59aa6170b990d8d2719323e628aaf36f3bfbc1c26279c0eeeb24d05d2d11c7"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win32.whl", hash = "sha256:beffaed67936fbbeffd10966a4eb53c402fafd3d6833770516bf7314bc6ffa12"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win_amd64.whl", hash = "sha256:040ae85536960525ea62868b642bdb0c2cc6021c9f9d507810c0c604e66f5a7b"},
+    {file = "ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f"},
+]
 
 [[package]]
 name = "ruff"
@@ -745,4 +842,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.13"
-content-hash = "06b8c6c66393827ab08f250511852c2e888e19ef78e94b6b9aaf9261457ba7ab"
+content-hash = "2dc743ec2bdfd2dbbe065b9cad33a2c5625f49a61b4bcc174c420ce460642b2f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "feedly-client (>=0.26,<0.27)",
     "logzero (>=1.7.0,<2.0.0)",
     "pydantic (>=2.11.7,<3.0.0)",
+    "pydantic-yaml (>=1.6.0,<2.0.0)",
     "todoist-api-python (>=3.1.0,<4.0.0)",
     "typer (>=0.16.0,<0.17.0)"
 ]

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,153 @@
+"""Tests for the config_loader module."""
+
+from pathlib import Path
+
+import pytest
+
+from feedly_saved_entries_processor.config_loader import (
+    Config,
+    MatchConfig,
+    Rule,
+    load_config,
+    save_config,
+)
+
+
+@pytest.fixture
+def temp_config_file(tmp_path: Path) -> Path:
+    """Provide a path to a temporary valid configuration file."""
+    content = """
+rules:
+  - name: "Test Rule 1"
+    match:
+      stream_id_in:
+        - "feed/test.com/1"
+        - "feed/test.com/2"
+    processor: "todoist"
+    processor_config:
+      project: "Inbox"
+      priority: 4
+
+  - name: "Test Rule 2"
+    match:
+      stream_id_in:
+        - "feed/test.com/3"
+    processor: "log_only"
+    processor_config:
+      level: "info"
+"""
+    file_path = tmp_path / "config.yaml"
+    file_path.write_text(content)
+    return file_path
+
+
+@pytest.fixture
+def invalid_yaml_file(tmp_path: Path) -> Path:
+    """Provide a path to a temporary invalid YAML file."""
+    content = """
+rules:
+  - name: "Test Rule 1"
+    match:
+      stream_id_in:
+        - "feed/test.com/1"
+        - "feed/test.com/2"
+    processor: "todoist"
+    processor_config:
+      project: "Inbox"
+      priority: 4
+
+  - name: "Test Rule 2"
+    match:
+      stream_id_in:
+        - "feed/test.com/3"
+    processor: "log_only"
+    processor_config:
+      level: "info"
+
+  - name: "Invalid YAML: missing colon"
+    match
+      stream_id_in:
+        - "feed/test.com/4"
+"""
+    file_path = tmp_path / "invalid_config.yaml"
+    file_path.write_text(content)
+    return file_path
+
+
+@pytest.fixture
+def invalid_structure_file(tmp_path: Path) -> Path:
+    """Provide a path to a temporary YAML file with invalid structure."""
+    content = """
+rules:
+  - name: "Test Rule 1"
+    # Missing 'match' key
+    processor: "todoist"
+    processor_config:
+      project: "Inbox"
+"""
+    file_path = tmp_path / "invalid_structure.yaml"
+    file_path.write_text(content)
+    return file_path
+
+
+def test_load_config_success(temp_config_file: Path) -> None:
+    """Test that a valid configuration file can be loaded successfully."""
+    config = load_config(temp_config_file)
+
+    assert isinstance(config, Config)
+    assert len(config.rules) == 2
+
+    rule1 = config.rules[0]
+    assert rule1.name == "Test Rule 1"
+    assert rule1.match.stream_id_in == ("feed/test.com/1", "feed/test.com/2")
+    assert rule1.processor == "todoist"
+    assert rule1.processor_config is not None
+    assert rule1.processor_config["project"] == "Inbox"
+    assert rule1.processor_config["priority"] == 4
+
+    rule2 = config.rules[1]
+    assert rule2.name == "Test Rule 2"
+    assert rule2.match.stream_id_in == ("feed/test.com/3",)
+    assert rule2.processor == "log_only"
+    assert rule2.processor_config is not None
+    assert rule2.processor_config["level"] == "info"
+
+
+def test_load_config_file_not_found(tmp_path: Path) -> None:
+    """Test that FileNotFoundError is raised for a non-existent file."""
+    non_existent_file = tmp_path / "non_existent.yaml"
+    with pytest.raises(FileNotFoundError):
+        load_config(non_existent_file)
+
+
+def test_load_config_invalid_yaml(invalid_yaml_file: Path) -> None:
+    """Test that ValueError is raised for an invalid YAML file."""
+    with pytest.raises(ValueError, match="Error parsing configuration file"):
+        load_config(invalid_yaml_file)
+
+
+def test_load_config_invalid_structure(invalid_structure_file: Path) -> None:
+    """Test that ValueError is raised for a YAML file with invalid structure."""
+    with pytest.raises(ValueError, match="Error parsing configuration file"):
+        load_config(invalid_structure_file)
+
+
+def test_save_config_and_load_back(tmp_path: Path) -> None:
+    """Test that a Config object can be saved and loaded back correctly."""
+    original_config = Config(
+        rules=[
+            Rule(
+                name="Saved Rule",
+                match=MatchConfig(stream_id_in=["feed/saved.com/1"]),
+                processor="test_processor",
+                processor_config={"key": "value"},
+            )
+        ]
+    )
+    output_file = tmp_path / "saved_config.yaml"
+
+    save_config(original_config, output_file)
+
+    loaded_config = load_config(output_file)
+
+    assert loaded_config == original_config


### PR DESCRIPTION
This commit introduces the foundational components for loading and validating application configuration from a YAML file.
- Adds `pydantic-yaml` dependency for Pydantic-based YAML serialization/deserialization.
- Implements `feedly_saved_entries_processor/config_loader.py` with Pydantic models (`MatchConfig`, `Rule`, `Config`) to define the configuration structure.
- Provides `load_config` and `save_config` functions for handling file I/O and Pydantic model validation.
- Ensures Pydantic models are immutable (`frozen=True`) and use `tuple` for lists.
- Adds comprehensive unit tests for `config_loader.py` to cover loading, saving, and validation scenarios.
