### PR TITLE
feat: Implement rule-based entry processing

### DIFF
--- a/feedly_saved_entries_processor/main.py
+++ b/feedly_saved_entries_processor/main.py
@@ -1,5 +1,6 @@
 """CLI application."""
 
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Annotated
 
@@ -7,13 +8,44 @@ import typer
 from feedly.api_client.session import FeedlySession, FileAuthStore
 from logzero import logger
 
-from feedly_saved_entries_processor.feedly_client import FeedlyClient
+from feedly_saved_entries_processor.config_loader import Rule, load_config
+from feedly_saved_entries_processor.feedly_client import Entry, FeedlyClient
 
 app = typer.Typer()
 
 
+def process_entry(entry: Entry, rule: Rule) -> None:
+    """Process a single Feedly entry based on a rule."""
+    try:
+        if rule.match.is_match(entry):
+            logger.info(
+                f"Entry '{entry.title}' (URL: {entry.canonical_url}) matched rule '{rule.name}'."
+            )
+            try:
+                rule.processor.process_entry(entry)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    f"Error processing entry '{entry.title}' (URL: {entry.canonical_url}) with rule '{rule.name}'."
+                )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            f"Error evaluating rule '{rule.name}' for entry '{entry.title}' (URL: {entry.canonical_url})."
+        )
+
+
+def process_entries(entries: Iterable[Entry], rules: Iterable[Rule]) -> None:
+    """Process Feedly entries based on configured rules."""
+    for entry in entries:
+        for rule in rules:
+            process_entry(entry, rule)
+
+
 @app.command()
 def main(
+    config_file: Annotated[
+        Path,
+        typer.Option(exists=True, file_okay=True, dir_okay=False),
+    ],
     token_dir: Annotated[
         Path | None,
         typer.Option(exists=True, file_okay=False),
@@ -22,11 +54,16 @@ def main(
     """Process saved entries."""
     if token_dir is None:
         token_dir = Path.home() / ".config" / "feedly"
+
+    config = load_config(config_file)
+    logger.info(f"Loaded {len(config.rules)} rules from {config_file}")
+
     auth = FileAuthStore(token_dir=token_dir)
     feedly_session = FeedlySession(auth=auth)
     client = FeedlyClient(feedly_session=feedly_session)
-    entries = list(client.fetch_saved_entries())
-    logger.info(f"Number of saved entries: {len(entries)}")
+
+    entries = client.fetch_saved_entries()
+    process_entries(entries=entries, rules=config.rules)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactor the main application logic to introduce a rule-based system for processing saved Feedly entries.

- Add `process_entry` and `process_entries` functions to handle the core processing loop.
- Update the `main` function to accept a `--config-file` argument.
- Load processing rules from the specified configuration file.
- Pass the fetched entries and loaded rules to the new processing functions.
- Include error handling for both rule evaluation and entry processing.
