### PR TITLE
chore(mypy): Use .gitignore to exclude files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
+exclude_gitignore = true
 strict = true
-exclude = [".venv", "build", "dist"]
 plugins = "pydantic.mypy"
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
Update mypy configuration in pyproject.toml to use exclude_gitignore = true.
This replaces the static exclude list and makes the exclusion logic more maintainable by respecting the project's .gitignore file.
