### PR TITLE
ci: Update workflow to trigger on main branch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: Workflow
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
     branches: ["**"]


### PR DESCRIPTION
The default branch for this repository is main, but the workflow was still configured to trigger on master. This commit updates the push trigger to correctly point to the main branch.
