### PR TITLE
feat: Update script entry point in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.scripts]
-feedly-saved-entries-processor = "feedly_saved_entries_processor.main:app"
+feedly-saved-entries-processor = "feedly_saved_entries_processor.__main__:app"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
Update the script entry point to point to __main__:app following the renaming of main.py.
