### PR TITLE
feat: Remove automated PR creation step and reduce PAT usage

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -164,26 +164,3 @@ jobs:
           git add pyproject.toml
           git commit -m "build: update version to ${{ steps.update_version.outputs.new_version }}"
           git push --force origin "$BRANCH_NAME"
-
-      - name: Create/Update Pull Request
-        if: steps.update_version.outputs.version_updated == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_FOR_CREATING_PR }}
-        run: |
-          BRANCH_NAME="${{ steps.prepare_branch.outputs.branch_name }}"
-          PR_STATE=$(gh pr view "$BRANCH_NAME" --json state --jq .state 2>/dev/null)
-
-          if [[ "$PR_STATE" == "OPEN" ]]; then
-            echo "An open pull request for branch '$BRANCH_NAME' already exists. It has been updated by the push."
-          else
-            if [[ -n "$PR_STATE" ]]; then
-              echo "A pull request for branch '$BRANCH_NAME' exists but is not open (state: $PR_STATE). Creating a new one."
-            else
-              echo "No pull request found for branch '$BRANCH_NAME'. Creating a new one."
-            fi
-            gh pr create \
-              --title "build: Propose version update to ${{ steps.update_version.outputs.new_version }}" \
-              --body "This PR proposes an update to the project version. Merging this PR will trigger a new release." \
-              --head "$BRANCH_NAME" \
-              --base "main"
-          fi


### PR DESCRIPTION
The automated pull request creation and update step has been removed from the workflow.
This simplifies the CI/CD process by no longer automatically generating PRs for version updates,
and also reduces security risks by eliminating the need for a Personal Access Token (PAT) in this step.
